### PR TITLE
feat: Add automated repository setup script and fix documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,22 +6,22 @@ We welcome contributions to the NHS RAP Cookiecutter Template.
 
 1. Clone the repository:
 
-```bash
-git clone https://github.com/nhsengland/nhse-rap-cookiecutter.git
-cd nhse-rap-cookiecutter
-```
+   ```bash
+   git clone https://github.com/nhsengland/nhse-rap-cookiecutter.git
+   cd nhse-rap-cookiecutter
+   ```
 
-1. Install dependencies:
+2. Install dependencies:
 
-```bash
-uv sync --all-extras
-```
+   ```bash
+   uv sync --all-extras
+   ```
 
-1. Install pre-commit hooks:
+3. Install pre-commit hooks:
 
-```bash
-uv run pre-commit install
-```
+   ```bash
+   uv run pre-commit install
+   ```
 
 ## Running Tests
 
@@ -36,6 +36,27 @@ uv run pytest tests/ --cov=nhse_rap_cookiecutter --cov-report=term-missing
 
 # Run specific test file
 uv run pytest tests/test_cli.py -v
+
+# Run tests across multiple Python versions with tox
+uv run tox
+
+# Run tox for specific Python version
+uv run tox -e py310  # or py311, py312, py313
+```
+
+### Testing Across Python Versions
+
+The project uses `tox` to test across Python 3.10-3.13:
+
+```bash
+# Run all Python versions
+uv run tox
+
+# Run specific version
+uv run tox -e py312
+
+# Run in parallel
+uv run tox -p
 ```
 
 ## Code Quality
@@ -94,6 +115,7 @@ Copyright (c) 2026 NHS England
 This ensures generated projects always display the current year without manual updates.
 
 **Files using dynamic years:**
+
 - `{{ cookiecutter.repo_name }}/LICENSE` - Uses cookiecutter's `{% now 'utc', '%Y' %}`
 - `{{ cookiecutter.repo_name }}/docs/content/overrides/partials/footer.html` - Uses MkDocs' `{{ "now().year" }}`
 - `docs/overrides/partials/footer.html` - Cookiecutter repo footer, uses MkDocs' `{{ "now().year" }}`

--- a/README.md
+++ b/README.md
@@ -79,8 +79,10 @@ The template prompts for the following information:
 
 | Category | Option | Description | Choices |
 |----------|--------|-------------|---------|
-| **Project** | project_name | Human-readable project name | Text || | repo_name | Repository name (default: lowercase project_name with underscores) | Text |
-| | module_name | Python module name (default: repo_name with dashes converted to underscores) | Text || | description | Brief project description | Text |
+| **Project** | project_name | Human-readable project name | Text |
+| | repo_name | Repository name (default: lowercase project_name with underscores) | Text |
+| | module_name | Python module name (default: repo_name with dashes converted to underscores) | Text |
+| | description | Brief project description | Text |
 | | author_name | Your full name | Text |
 | | author_email | Your email address | Text |
 | | organization_name | Your organisation name (default: NHS England) | Text |

--- a/README.md
+++ b/README.md
@@ -79,19 +79,21 @@ The template prompts for the following information:
 
 | Category | Option | Description | Choices |
 |----------|--------|-------------|---------|
-| **Project** | project_name | Human-readable project name | Text |
-| | description | Brief project description | Text |
+| **Project** | project_name | Human-readable project name | Text || | repo_name | Repository name (default: lowercase project_name with underscores) | Text |
+| | module_name | Python module name (default: repo_name with dashes converted to underscores) | Text || | description | Brief project description | Text |
 | | author_name | Your full name | Text |
 | | author_email | Your email address | Text |
-| | organization_name | Your organisation (fixed: NHS England) | Text |
+| | organization_name | Your organisation name (default: NHS England) | Text |
 | | team_name | Your team name | Text |
-| | team_email | Team contact email (optional) | Text |
+| | team_email | Team contact email | Text |
+| | git_hosting_platform | Git hosting platform | github, gitlab, azure_devops, other |
+| | repository_url | Repository URL (can override default) | Text |
 | **Python** | python_version_number | Minimum Python version | 3.10, 3.11, 3.12, 3.13 |
-| | environment_manager | Virtual environment tool | virtualenv, conda, pipenv, uv, pixi, poetry, none |
-| **Options** | include_code_scaffold | Include example code modules | yes, no |
+| | environment_manager | Virtual environment tool | uv, virtualenv, conda, pipenv, pixi, poetry, none |
+| **Options** | include_code_scaffold | Include example code modules | Yes, No |
 | | linting_and_formatting | Code quality tools | ruff, flake8+black+isort |
-| | license | Project licence | MIT, BSD-3-Clause, none |
-| | documentation | Documentation tool | mkdocs, none |
+| | open_source_license | Project licence | MIT, Apache-2.0, GPL-3.0, No license file |
+| | docs | Documentation tool | mkdocs, none |
 
 **Note**: All generated projects include core Python packages (pandas, numpy, matplotlib, seaborn, jupyter, etc.) and development tools (pytest, pre-commit, linting) by default. The dependency file format (pyproject.toml or environment.yml) is determined automatically based on your environment manager choice.
 
@@ -110,9 +112,11 @@ your-project/
 ├── references/          # Data dictionaries and documentation
 ├── reports/
 │   └── figures/         # Generated graphics
+├── scripts/             # Setup and utility scripts
+│   └── setup_repository.py  # Automated repository setup
 ├── tests/
-│   ├── pytest/          # Pytest tests
-│   └── unittest/        # Unittest tests
+│   ├── unittests/       # Unit tests (pytest)
+│   └── e2e/             # End-to-end integration tests
 ├── your_module/         # Source code package
 │   ├── __init__.py
 │   ├── config.py        # Configuration management
@@ -122,11 +126,18 @@ your-project/
 │   └── modeling/
 │       ├── train.py     # Model training
 │       └── predict.py   # Model inference
-├── LICENSE
-├── OPEN_CODE_CHECKLIST.md  # NHS England standards for publishing code
+├── .env                 # Environment variables (not tracked in git)
+├── .pre-commit-config.yaml  # Pre-commit hooks configuration
+├── badges.toml          # Optional project badges
+├── CODE_OF_CONDUCT.md   # Community guidelines
+├── LICENSE              # Project license
+├── LICENSE-OGL          # Open Government License for docs
 ├── Makefile             # Convenience commands
+├── mkdocs.yml           # Documentation configuration
+├── OPEN_CODE_CHECKLIST.md  # NHS England standards for publishing code
 ├── README.md
-└── pyproject.toml       # Project configuration and dependencies
+├── pyproject.toml       # Project configuration and dependencies
+└── setup.cfg            # Legacy tool configuration (flake8 only)
 ```
 
 ## Key Features
@@ -145,7 +156,23 @@ The checklist is also integrated into the project documentation for easy referen
 
 ## Using the Generated Project
 
-After generating a project:
+After generating a project, use the automated setup script:
+
+```bash
+cd your-project-name
+make setup
+```
+
+The setup script will:
+
+- Initialize git repository with default branch
+- Configure git remote with your repository URL
+- Set up your Python environment (uv, conda, poetry, etc.)
+- Install all project dependencies
+- Install pre-commit hooks
+- Create an initial commit
+
+Alternatively, you can set up manually:
 
 ```bash
 cd your-project-name

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -13,10 +13,10 @@
     "python_version_number": ["3.10", "3.11", "3.12", "3.13"],
     "year": "{% now 'utc', '%Y' %}",
     "environment_manager": [
+        "uv",
         "virtualenv",
         "conda",
         "pipenv",
-        "uv",
         "pixi",
         "poetry",
         "none"

--- a/docs/content/contributing.md
+++ b/docs/content/contributing.md
@@ -13,15 +13,43 @@ We welcome contributions to the NHS RAP Cookiecutter Template.
 
 2. Install dependencies:
 
-   ```bash
-   uv sync --all-extras
-   ```
+    === "UV (Recommended)"
+
+        ```bash
+        uv sync --all-extras
+        ```
+
+    === "Poetry"
+
+        ```bash
+        poetry install --all-extras
+        ```
+
+    === "Pip"
+
+        ```bash
+        pip install -e .[dev,test,docs]
+        ```
 
 3. Install pre-commit hooks:
 
-   ```bash
-   uv run pre-commit install
-   ```
+    === "UV"
+
+        ```bash
+        uv run pre-commit install
+        ```
+
+    === "Poetry"
+
+        ```bash
+        poetry run pre-commit install
+        ```
+
+    === "Activated Environment"
+
+        ```bash
+        pre-commit install
+        ```
 
 ## Making Changes
 
@@ -36,13 +64,29 @@ git checkout -b feature/your-feature-name
 All tests must pass before submitting changes:
 
 ```bash
-uv run pytest tests/ -v
+make test  # or: uv run pytest tests/ -v
 ```
 
 With coverage:
 
 ```bash
-uv run pytest tests/ --cov=nhse_rap_cookiecutter --cov-report=term-missing
+=== "UV"
+
+    ```bash
+    uv run pytest tests/ --cov=nhse_rap_cookiecutter --cov-report=term-missing
+    ```
+
+=== "Poetry"
+
+    ```bash
+    poetry run pytest tests/ --cov=nhse_rap_cookiecutter --cov-report=term-missing
+    ```
+
+=== "Activated Environment"
+
+    ```bash
+    pytest tests/ --cov=nhse_rap_cookiecutter --cov-report=term-missing
+    ```
 ```
 
 ### Code Quality

--- a/docs/content/contributing.md
+++ b/docs/content/contributing.md
@@ -69,7 +69,6 @@ make test  # or: uv run pytest tests/ -v
 
 With coverage:
 
-```bash
 === "UV"
 
     ```bash
@@ -87,7 +86,6 @@ With coverage:
     ```bash
     pytest tests/ --cov=nhse_rap_cookiecutter --cov-report=term-missing
     ```
-```
 
 ### Code Quality
 

--- a/docs/content/getting_started.md
+++ b/docs/content/getting_started.md
@@ -108,24 +108,74 @@ Choose from 1, 2, 3, 4, 5, 6, 7 [1]: 4
 
 ## Quick Start After Creation
 
-After your project is created:
+After your project is created, use the automated setup script:
 
 ```bash
 # Navigate to your project
 cd my_nhs_analysis
 
-# Set up environment (if using UV)
-uv sync
-
-# Install pre-commit hooks
-uv run pre-commit install
-
-# Run tests
-uv run pytest tests/
-
-# Build documentation
-uv run mkdocs serve
+# Run automated setup
+make setup
 ```
+
+The setup script will:
+
+- Initialize git repository with default branch
+- Configure git remote with your repository URL
+- Set up your Python environment (uv, conda, poetry, etc.)
+- Install all project dependencies
+- Install pre-commit hooks
+- Create an initial commit
+
+### Manual Commands
+
+If you prefer to set up manually or need to run individual steps, use your chosen environment manager's commands:
+
+=== "UV"
+
+    ```bash
+    uv sync
+    uv run pre-commit install
+    make test
+    make docs
+    ```
+
+=== "Conda"
+
+    ```bash
+    conda env create -f environment.yml
+    conda activate your_project
+    pre-commit install
+    make test
+    make docs
+    ```
+
+=== "Poetry"
+
+    ```bash
+    poetry install
+    poetry run pre-commit install
+    make test
+    make docs
+    ```
+
+=== "Pipenv"
+
+    ```bash
+    pipenv install --dev
+    pipenv run pre-commit install
+    make test
+    make docs
+    ```
+
+=== "Pixi"
+
+    ```bash
+    pixi install
+    pixi run pre-commit install
+    make test
+    make docs
+    ```
 
 ## Next Steps
 

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -92,8 +92,10 @@ The template prompts for the following:
 
 | Category | Option | Description | Choices |
 |----------|--------|-------------|---------|
-| **Project** | project_name | Human-readable project name | Text || | repo_name | Repository name (default: lowercase project_name with underscores) | Text |
-| | module_name | Python module name (default: repo_name with dashes converted to underscores) | Text || | description | Brief project description | Text |
+| **Project** | project_name | Human-readable project name | Text |
+| | repo_name | Repository name (default: lowercase project_name with underscores) | Text |
+| | module_name | Python module name (default: repo_name with dashes converted to underscores) | Text |
+| | description | Brief project description | Text |
 | | author_name | Your full name | Text |
 | | author_email | Your email address | Text |
 | | organization_name | Your organisation name (default: NHS England) | Text |

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -92,19 +92,21 @@ The template prompts for the following:
 
 | Category | Option | Description | Choices |
 |----------|--------|-------------|---------|
-| **Project** | project_name | Human-readable project name | Text |
-| | description | Brief project description | Text |
+| **Project** | project_name | Human-readable project name | Text || | repo_name | Repository name (default: lowercase project_name with underscores) | Text |
+| | module_name | Python module name (default: repo_name with dashes converted to underscores) | Text || | description | Brief project description | Text |
 | | author_name | Your full name | Text |
 | | author_email | Your email address | Text |
-| | organization_name | Your organisation (fixed: NHS England) | Text |
+| | organization_name | Your organisation name (default: NHS England) | Text |
 | | team_name | Your team name | Text |
-| | team_email | Team contact email (optional) | Text |
+| | team_email | Team contact email | Text |
+| | git_hosting_platform | Git hosting platform | github, gitlab, azure_devops, other |
+| | repository_url | Repository URL (can override default) | Text |
 | **Python** | python_version_number | Minimum Python version | 3.10, 3.11, 3.12, 3.13 |
-| | environment_manager | Virtual environment tool | virtualenv, conda, pipenv, uv, pixi, poetry, none |
-| **Options** | include_code_scaffold | Include example code modules | yes, no |
+| | environment_manager | Virtual environment tool | uv, virtualenv, conda, pipenv, pixi, poetry, none |
+| **Options** | include_code_scaffold | Include example code modules | Yes, No |
 | | linting_and_formatting | Code quality tools | ruff, flake8+black+isort |
-| | license | Project licence | MIT, BSD-3-Clause, none |
-| | documentation | Documentation tool | mkdocs, none |
+| | open_source_license | Project licence | MIT, Apache-2.0, GPL-3.0, No license file |
+| | docs | Documentation tool | mkdocs, none |
 
 ---
 
@@ -123,6 +125,8 @@ your-project/
 ├── references/          # Data dictionaries and documentation
 ├── reports/
 │   └── figures/         # Generated graphics
+├── scripts/             # Setup and utility scripts
+│   └── setup_repository.py  # Automated repository setup
 ├── tests/
 │   ├── unittests/       # Unit tests (pytest)
 │   └── e2e/             # End-to-end integration tests
@@ -135,10 +139,18 @@ your-project/
 │   └── modeling/
 │       ├── train.py     # Model training
 │       └── predict.py   # Model inference
-├── LICENSE
+├── .env                 # Environment variables (not tracked in git)
+├── .pre-commit-config.yaml  # Pre-commit hooks configuration
+├── badges.toml          # Optional project badges
+├── CODE_OF_CONDUCT.md   # Community guidelines
+├── LICENSE              # Project license
+├── LICENSE-OGL          # Open Government License for docs
 ├── Makefile             # Convenience commands
+├── mkdocs.yml           # Documentation configuration
+├── OPEN_CODE_CHECKLIST.md  # NHS England standards for publishing code
 ├── README.md
-└── pyproject.toml       # Project configuration and dependencies
+├── pyproject.toml       # Project configuration and dependencies
+└── setup.cfg            # Legacy tool configuration (flake8 only)
 ```
 
 Each directory serves a specific purpose in the RAP workflow. The structure follows data science best practices while accommodating NHS-specific requirements.

--- a/docs/content/usage.md
+++ b/docs/content/usage.md
@@ -93,14 +93,18 @@ cookiecutter gh:nhsengland/nhse-rap-cookiecutter --checkout v1.0.0
 When you run `nhs-rap-template`, you'll be prompted for:
 
 - **Project Name**: Human-readable name (e.g., "My Analysis Project")
+- **Repository Name**: Repository name (defaults to lowercase project name with underscores)
+- **Module Name**: Python module name (defaults to repository name with dashes as underscores)
 - **Author Details**: Your name and email
-- **Organization**: Organization name and contact email (used in LICENSE)
+- **Organization**: Organization name (default: NHS England) and team contact email
+- **Git Hosting Platform**: github, gitlab, azure_devops, or other
+- **Repository URL**: Your repository URL (defaults to GitHub format, can be overridden)
 - **Python Version**: Minimum Python version (3.10-3.13)
-- **Environment Manager**: virtualenv, conda, pipenv, uv, pixi, poetry, or none
-- **License**: MIT, Apache-2.0, GPL-3.0, or no license
-- **Documentation**: mkdocs or none
+- **Environment Manager**: uv, virtualenv, conda, pipenv, pixi, poetry, or none
 - **Linting/Formatting**: ruff or flake8+black+isort
-- **Code Scaffold**: Include example code modules
+- **License**: MIT, Apache-2.0, GPL-3.0, or No license file
+- **Documentation**: mkdocs or none
+- **Code Scaffold**: Include example code modules (Yes or No)
 
 ### Included Packages
 
@@ -142,19 +146,15 @@ After creating your project:
    cd your-project-name
    ```
 
-2. **Create environment** (if using UV):
+2. **Run automated setup**:
 
    ```bash
-   uv sync
+   make setup
    ```
 
-3. **Set up pre-commit** (optional but recommended):
+   This sets up your environment, installs dependencies, configures git, and installs pre-commit hooks.
 
-   ```bash
-   uv run pre-commit install
-   ```
-
-4. **Start developing**:
+3. **Start developing**:
    - Add your code to the module folder
    - Add tests to the `tests/` folder
    - Update documentation in `docs/`
@@ -172,37 +172,55 @@ All generated files can be customised:
 
 ### Adding Dependencies
 
-With UV:
+Add dependencies to your project:
 
-```bash
-uv add pandas numpy
-```
+=== "UV"
 
-With pip:
+    ```bash
+    uv add pandas numpy
+    ```
 
-```bash
-pip install pandas numpy
-pip freeze > requirements.txt
-```
+=== "Poetry"
+
+    ```bash
+    poetry add pandas numpy
+    ```
+
+=== "Conda"
+
+    ```bash
+    # Edit environment.yml, then:
+    conda install pandas numpy
+    ```
+
+=== "Pipenv"
+
+    ```bash
+    pipenv install pandas numpy
+    ```
+
+=== "Pixi"
+
+    ```bash
+    pixi add pandas numpy
+    ```
 
 ### Running Tests
 
 ```bash
 make test
-# or
-uv run pytest tests/
 ```
+
+The Makefile automatically uses your chosen environment manager's run command.
 
 ### Building Documentation
 
 ```bash
 make docs        # Serve with live reload
 make docs-build  # Build static site
-# or
-uv run mkdocs serve
 ```
 
-For projects using `poetry` or `pixi`, `make docs` and `make docs-build` assume your environment is already activated (for example, via `poetry shell` or `pixi shell`).
+The Makefile handles the correct command for your environment manager.
 
 ### Code Quality Checks
 
@@ -285,59 +303,74 @@ cookiecutter ../nhse-rap-cookiecutter
 
 ### Customizing Badges
 
-The generated project includes a comprehensive set of badges at the top of the README. These provide quick information about the project status, technology, and quality metrics.
+The generated project includes a comprehensive set of badges at the top of the README and a `badges.toml` file with a library of ready-to-use badges you can swap in and out.
 
 #### Default Badges
 
-Your generated project will include these badges automatically:
+Your generated project will include these badges automatically in the README:
 
 - **Project Status**: Active (default)
 - **RAP Status**: Work in Progress (default)
 - **Cookiecutter**: Links to cookiecutter project
 - **NHS England RAP**: Links to this template
 - **Python Version**: Automatically populated from your configuration
-- **License**: MIT or BSD-3-Clause (if selected during generation)
+- **License**: MIT, Apache-2.0, or GPL-3.0 (if selected during generation)
 - **Code Style**: Ruff or Black/Flake8/isort (based on your selection)
 - **Pre-commit**: Pre-commit enabled
 
-#### Updating Status Badges
+#### Using the Badge Library (badges.toml)
 
-**Project Status**: Change the badge to reflect your project's current state. You can uncomment the appropriate badge from the commented section or edit the default "Active" badge. Status options follow a data science repository lifecycle:
+Your project includes a `badges.toml` file with ready-to-use badge markdown. Simply copy and paste badges from this file into your README.md or docs/index.md.
 
-- **Concept**: Brainstorming phase, no code or only rough scripts
-- **WIP**: Work in progress, active development occurring
-- **PoC**: Proof of Concept, code exists to prove hypothesis but not production-ready
-- **MVP**: Minimum Viable Product, functional model/pipeline reliable for initial users
-- **Active**: Actively maintained and updated
-- **On Hold**: Development paused (data availability, shifting priorities, etc.)
-- **Archived**: Project finished or abandoned, read-only
+**Available in badges.toml:**
 
-**RAP Status**: Update to reflect your [Reproducible Analytical Pipeline maturity level](https://nhsdigital.github.io/rap-community-of-practice/introduction_to_RAP/levels_of_RAP/):
+**Project Status** (`[project_status]`):
 
-- **Work in Progress**: Beginning RAP journey
-- **Baseline**: Core RAP requirements met (version control, peer review, documentation)
-- **Silver**: Enhanced capabilities (automated testing, continuous integration, functions/classes)
-- **Gold**: Advanced practices (package/repository, error handling, logging, documentation website)
+- `concept` - Brainstorming phase, no code or only rough scripts
+- `wip` - Work in progress, active development occurring
+- `poc` - Proof of Concept, code exists to prove hypothesis but not production-ready
+- `mvp` - Minimum Viable Product, functional model/pipeline reliable for initial users
+- `active` - Actively maintained and updated (default)
+- `on_hold` - Development paused (data availability, shifting priorities, etc.)
+- `archived` - Project finished or abandoned, read-only
+
+**RAP Status** (`[rap_status]`) - [RAP maturity levels](https://nhsdigital.github.io/rap-community-of-practice/introduction_to_RAP/levels_of_RAP/):
+
+- `wip` - Beginning RAP journey (default)
+- `baseline` - Core RAP requirements met (version control, peer review, documentation)
+- `silver` - Enhanced capabilities (automated testing, continuous integration, functions/classes)
+- `gold` - Advanced practices (package/repository, error handling, logging, documentation website)
+
+**GitHub CI/CD Badges** (`[github]`) - if you selected GitHub as your hosting platform:
+
+- `tests` - Test workflow status
+- `lint` - Lint workflow status
+- `docs` - Documentation build status
+- `release` - Latest release version
+- `pages` - GitHub Pages documentation status
+
+**GitLab CI/CD Badges** (`[gitlab]`) - if you selected GitLab as your hosting platform:
+
+- `pipeline` - Pipeline status
+- `coverage` - Code coverage
+
+**Other Badges** (`[other]`):
+
+- `pypi` - PyPI version (if publishing to PyPI)
+- `ogl3` - Open Government License badge
+
+#### Example: Updating Project Status
+
+To change your project status from "Active" to "MVP", open `badges.toml` and copy the MVP badge:
+
+```toml
+mvp = "[![Project Status: MVP](https://img.shields.io/badge/Project%20Status-MVP-yellowgreen)](https://github.com/your-org/your-repo)"
+```
+
+Then replace the project status badge in your README.md with this copied badge markdown.
 
 #### Adding CI/CD Badges
 
-Once you set up GitHub Actions workflows, uncomment the relevant badges in the commented section of your README and ensure the workflow file names match your setup (e.g., `tests.yml`, `lint.yml`, `docs.yml`).
+Once you set up GitHub Actions or GitLab CI workflows, copy the relevant badges from the `[github]` or `[gitlab]` sections in `badges.toml`. The badges are pre-configured with your repository URL.
 
-Example workflow badges provided:
-
-```markdown
-[![Tests](https://github.com/nhsengland/your-project/actions/workflows/tests.yml/badge.svg)](https://github.com/nhsengland/your-project/actions/workflows/tests.yml)
-[![Lint](https://github.com/nhsengland/your-project/actions/workflows/lint.yml/badge.svg)](https://github.com/nhsengland/your-project/actions/workflows/lint.yml)
-[![Docs](https://github.com/nhsengland/your-project/actions/workflows/docs.yml/badge.svg)](https://github.com/nhsengland/your-project/actions/workflows/docs.yml)
-```
-
-#### Additional Optional Badges
-
-The commented section in your generated README includes many optional badges you can add:
-
-- **Documentation Status**: Link to your documentation site
-- **Latest Release**: Show current version from GitHub releases
-- **PyPI Version**: If publishing to PyPI
-- **OGL3 License**: For documentation (if applicable)
-
-For more badge options and customization, see [shields.io](https://shields.io/).
+For custom badge options and colors, see [shields.io](https://shields.io/).

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -131,6 +131,7 @@ class TestCLIProjectGeneration:
             "notebooks",
             "references",
             "reports",
+            "scripts",
             "tests",
         }
         actual_dirs = {d.name for d in project_path.iterdir() if d.is_dir()}

--- a/tests/test_cookiecutter.py
+++ b/tests/test_cookiecutter.py
@@ -86,6 +86,7 @@ class TestCookiecutterProjectGeneration:
             "notebooks",
             "references",
             "reports",
+            "scripts",
             "tests",
         }
         actual_dirs = {d.name for d in project_path.iterdir() if d.is_dir()}

--- a/tests/test_setup_script.py
+++ b/tests/test_setup_script.py
@@ -1,0 +1,116 @@
+"""Tests for setup_repository.py script in generated projects."""
+
+import pytest
+
+
+class TestSetupScript:
+    """Tests for setup script generation and functionality."""
+
+    def test_setup_script_exists(self, cookies):
+        """Setup script is created in generated project."""
+        result = cookies.bake()
+
+        assert result.exit_code == 0
+        setup_script = result.project_path / "scripts" / "setup_repository.py"
+        assert setup_script.exists()
+
+    def test_setup_script_is_executable(self, cookies):
+        """Setup script has correct shebang."""
+        result = cookies.bake()
+
+        assert result.exit_code == 0
+        setup_script = result.project_path / "scripts" / "setup_repository.py"
+        content = setup_script.read_text()
+        assert content.startswith("#!/usr/bin/env python3")
+
+    def test_setup_script_includes_project_name(self, cookies):
+        """Setup script includes the project name."""
+        result = cookies.bake(extra_context={"project_name": "Test Project"})
+
+        assert result.exit_code == 0
+        setup_script = result.project_path / "scripts" / "setup_repository.py"
+        content = setup_script.read_text()
+        assert "Test Project" in content
+
+    def test_setup_script_includes_repository_url(self, cookies):
+        """Setup script includes the repository URL."""
+        test_url = "https://github.com/test/test-repo"
+        result = cookies.bake(extra_context={"repository_url": test_url})
+
+        assert result.exit_code == 0
+        setup_script = result.project_path / "scripts" / "setup_repository.py"
+        content = setup_script.read_text()
+        assert test_url in content
+
+    def test_setup_script_includes_environment_manager(self, cookies):
+        """Setup script references the selected environment manager."""
+        result = cookies.bake(extra_context={"environment_manager": "uv"})
+
+        assert result.exit_code == 0
+        setup_script = result.project_path / "scripts" / "setup_repository.py"
+        content = setup_script.read_text()
+        assert "uv" in content
+
+    def test_setup_script_syntax_is_valid(self, cookies):
+        """Setup script has valid Python syntax."""
+        result = cookies.bake()
+
+        assert result.exit_code == 0
+        setup_script = result.project_path / "scripts" / "setup_repository.py"
+
+        # Check syntax by compiling
+        content = setup_script.read_text()
+        try:
+            compile(content, str(setup_script), "exec")
+        except SyntaxError as e:
+            pytest.fail(f"Setup script has invalid syntax: {e}")
+
+
+class TestSetupScriptForEnvironmentManagers:
+    """Tests for setup script with different environment managers."""
+
+    @pytest.mark.parametrize(
+        "env_manager",
+        ["virtualenv", "conda", "pipenv", "uv", "pixi", "poetry", "none"],
+    )
+    def test_setup_script_handles_environment_manager(self, cookies, env_manager):
+        """Setup script includes logic for each environment manager."""
+        result = cookies.bake(extra_context={"environment_manager": env_manager})
+
+        assert result.exit_code == 0
+        setup_script = result.project_path / "scripts" / "setup_repository.py"
+        content = setup_script.read_text()
+
+        if env_manager != "none":
+            assert env_manager in content
+
+
+class TestSetupScriptDocumentation:
+    """Tests for setup script documentation strings."""
+
+    def test_setup_script_has_module_docstring(self, cookies):
+        """Setup script has a module-level docstring."""
+        result = cookies.bake()
+
+        assert result.exit_code == 0
+        setup_script = result.project_path / "scripts" / "setup_repository.py"
+        content = setup_script.read_text()
+        assert '"""Repository setup script' in content
+
+    def test_setup_script_functions_have_docstrings(self, cookies):
+        """Setup script functions have docstrings."""
+        result = cookies.bake()
+
+        assert result.exit_code == 0
+        setup_script = result.project_path / "scripts" / "setup_repository.py"
+        content = setup_script.read_text()
+
+        # Check key functions have docstrings
+        assert "def setup_git_repository()" in content
+        assert '"""Initialize git repository' in content
+
+        assert "def setup_environment()" in content
+        assert '"""Set up Python environment' in content
+
+        assert "def setup_precommit()" in content
+        assert '"""Install pre-commit hooks' in content

--- a/tests/test_setup_script_features.py
+++ b/tests/test_setup_script_features.py
@@ -1,0 +1,180 @@
+"""Tests for new setup_repository.py features: colors, status tracking, error handling."""
+
+
+class TestSetupScriptColorSupport:
+    """Tests for colored terminal output."""
+
+    def test_setup_script_has_color_class(self, cookies):
+        """Setup script defines Colors class for ANSI codes."""
+        result = cookies.bake()
+
+        assert result.exit_code == 0
+        setup_script = result.project_path / "scripts" / "setup_repository.py"
+        content = setup_script.read_text()
+        assert "class Colors:" in content
+        assert "GREEN =" in content
+        assert "YELLOW =" in content
+        assert "RED =" in content
+        assert "RESET =" in content
+
+    def test_setup_script_uses_colored_output(self, cookies):
+        """Setup script uses colored output for status messages."""
+        result = cookies.bake()
+
+        assert result.exit_code == 0
+        setup_script = result.project_path / "scripts" / "setup_repository.py"
+        content = setup_script.read_text()
+        # Check for colored checkmarks and status messages
+        assert "Colors.GREEN" in content
+        assert "Colors.YELLOW" in content
+        assert "Colors.RED" in content
+
+
+class TestSetupScriptStatusTracking:
+    """Tests for status tracking functionality."""
+
+    def test_setup_script_has_status_class(self, cookies):
+        """Setup script defines SetupStatus class."""
+        result = cookies.bake()
+
+        assert result.exit_code == 0
+        setup_script = result.project_path / "scripts" / "setup_repository.py"
+        content = setup_script.read_text()
+        assert "class SetupStatus:" in content
+        assert "git_init" in content
+        assert "git_remote" in content
+        assert "environment" in content
+        assert "dependencies" in content
+        assert "precommit" in content
+        assert "initial_commit" in content
+
+    def test_setup_script_creates_status_instance(self, cookies):
+        """Setup script creates a global status instance."""
+        result = cookies.bake()
+
+        assert result.exit_code == 0
+        setup_script = result.project_path / "scripts" / "setup_repository.py"
+        content = setup_script.read_text()
+        assert "status = SetupStatus()" in content
+
+
+class TestSetupScriptErrorHandling:
+    """Tests for error handling and graceful failures."""
+
+    def test_setup_script_has_setup_error_exception(self, cookies):
+        """Setup script defines SetupError exception."""
+        result = cookies.bake()
+
+        assert result.exit_code == 0
+        setup_script = result.project_path / "scripts" / "setup_repository.py"
+        content = setup_script.read_text()
+        assert "class SetupError(Exception):" in content
+
+    def test_setup_script_wraps_steps_in_try_except(self, cookies):
+        """Setup script wraps each step in try-except blocks."""
+        result = cookies.bake()
+
+        assert result.exit_code == 0
+        setup_script = result.project_path / "scripts" / "setup_repository.py"
+        content = setup_script.read_text()
+        # Check that main function has try-except for each step
+        assert "# Step 1: Git initialization" in content
+        assert "# Step 2: Git remote setup" in content
+        assert "# Step 3: Environment setup" in content
+        assert "# Step 4: Dependencies" in content
+        assert "# Step 5: Pre-commit hooks" in content
+        assert "# Step 6: Initial commit" in content
+        assert "except SetupError" in content
+        assert "except subprocess.CalledProcessError" in content
+
+    def test_setup_script_skips_dependent_steps_on_env_failure(self, cookies):
+        """Setup script skips remaining steps if environment fails."""
+        result = cookies.bake()
+
+        assert result.exit_code == 0
+        setup_script = result.project_path / "scripts" / "setup_repository.py"
+        content = setup_script.read_text()
+        assert "Skipping remaining steps that require the environment" in content
+        assert "print_next_steps()" in content
+        assert "return" in content
+
+    def test_setup_script_always_shows_summary(self, cookies):
+        """Setup script always shows next steps even on failure."""
+        result = cookies.bake()
+
+        assert result.exit_code == 0
+        setup_script = result.project_path / "scripts" / "setup_repository.py"
+        content = setup_script.read_text()
+        # print_next_steps should be called in success path and error paths
+        assert content.count("print_next_steps()") >= 2
+
+
+class TestSetupScriptSummary:
+    """Tests for setup summary output."""
+
+    def test_setup_script_has_format_status_function(self, cookies):
+        """Setup script has function to format status with colors."""
+        result = cookies.bake()
+
+        assert result.exit_code == 0
+        setup_script = result.project_path / "scripts" / "setup_repository.py"
+        content = setup_script.read_text()
+        assert "def format_status(" in content
+        assert "Success" in content
+        assert "Skipped" in content
+        assert "Warning" in content
+        assert "Failed" in content
+
+    def test_setup_script_shows_detailed_summary(self, cookies):
+        """Setup script prints detailed summary of all steps."""
+        result = cookies.bake()
+
+        assert result.exit_code == 0
+        setup_script = result.project_path / "scripts" / "setup_repository.py"
+        content = setup_script.read_text()
+        assert "SETUP SUMMARY" in content
+        assert "Setup Steps:" in content
+        assert "Overall Status:" in content
+        assert "format_status(status." in content
+
+
+class TestSetupScriptRemoteWarning:
+    """Tests for clear remote repository warnings."""
+
+    def test_setup_script_has_clear_remote_warning(self, cookies):
+        """Setup script shows clear warning when remote doesn't exist."""
+        result = cookies.bake()
+
+        assert result.exit_code == 0
+        setup_script = result.project_path / "scripts" / "setup_repository.py"
+        content = setup_script.read_text()
+        assert "REMOTE REPOSITORY DOES NOT EXIST YET" in content
+        assert "This is normal for new projects!" in content
+        assert "BEFORE YOU CAN PUSH, you must:" in content
+
+    def test_setup_script_provides_remote_creation_steps(self, cookies):
+        """Setup script gives step-by-step instructions for creating remote."""
+        result = cookies.bake()
+
+        assert result.exit_code == 0
+        setup_script = result.project_path / "scripts" / "setup_repository.py"
+        content = setup_script.read_text()
+        assert "Go to your git hosting platform" in content
+        assert "DO NOT initialize with README" in content
+        assert "git push -u origin main" in content
+
+
+class TestSetupScriptPrecommitMessaging:
+    """Tests for clear pre-commit failure explanations."""
+
+    def test_setup_script_explains_precommit_failures(self, cookies):
+        """Setup script explains that pre-commit failures are expected."""
+        result = cookies.bake()
+
+        assert result.exit_code == 0
+        setup_script = result.project_path / "scripts" / "setup_repository.py"
+        content = setup_script.read_text()
+        assert "RUNNING PRE-COMMIT HOOKS - FAILURES ARE EXPECTED AND NORMAL!" in content
+        assert "cookiecutter template generates files with minor formatting issues" in content
+        assert '"Failed" means the hooks found and fixed formatting issues' in content
+        assert "working correctly!" in content

--- a/{{ cookiecutter.repo_name }}/Makefile
+++ b/{{ cookiecutter.repo_name }}/Makefile
@@ -4,11 +4,37 @@
 
 PROJECT_NAME = {{ cookiecutter.repo_name }}
 PYTHON_VERSION = {{ cookiecutter.python_version_number }}
+{% if cookiecutter.environment_manager == 'uv' -%}
+PYTHON_INTERPRETER = uv run python
+RUN_PREFIX = uv run
+{% elif cookiecutter.environment_manager == 'poetry' -%}
+PYTHON_INTERPRETER = poetry run python
+RUN_PREFIX = poetry run
+{% elif cookiecutter.environment_manager == 'pixi' -%}
+PYTHON_INTERPRETER = pixi run python
+RUN_PREFIX = pixi run
+{% elif cookiecutter.environment_manager == 'pipenv' -%}
+PYTHON_INTERPRETER = pipenv run python
+RUN_PREFIX = pipenv run
+{% elif cookiecutter.environment_manager == 'conda' -%}
 PYTHON_INTERPRETER = python
+RUN_PREFIX = 
+{% elif cookiecutter.environment_manager == 'virtualenv' -%}
+PYTHON_INTERPRETER = python
+RUN_PREFIX = 
+{% else -%}
+PYTHON_INTERPRETER = python
+RUN_PREFIX = 
+{% endif %}
 
 #################################################################################
 # COMMANDS                                                                      #
 #################################################################################
+
+## Initialize repository (run once after generating from template)
+.PHONY: setup
+setup:
+	$(PYTHON_INTERPRETER) scripts/setup_repository.py
 
 ## Install Python dependencies
 .PHONY: requirements
@@ -41,107 +67,44 @@ clean:
 ## Lint using ruff (use `make format` to do formatting)
 .PHONY: lint
 lint:
-	{% if cookiecutter.environment_manager == 'uv' -%}
-	uv run ruff format --check
-	uv run ruff check
-	{% elif cookiecutter.environment_manager == 'poetry' -%}
-	poetry run ruff format --check
-	poetry run ruff check
-	{% elif cookiecutter.environment_manager == 'pixi' -%}
-	pixi run ruff format --check
-	pixi run ruff check
-	{% else -%}
-	ruff format --check
-	ruff check
-	{% endif %}
+	$(RUN_PREFIX) ruff format --check
+	$(RUN_PREFIX) ruff check
 
 ## Format source code with ruff
 .PHONY: format
 format:
-	{% if cookiecutter.environment_manager == 'uv' -%}
-	uv run ruff check --fix
-	uv run ruff format
-	{% elif cookiecutter.environment_manager == 'poetry' -%}
-	poetry run ruff check --fix
-	poetry run ruff format
-	{% elif cookiecutter.environment_manager == 'pixi' -%}
-	pixi run ruff check --fix
-	pixi run ruff format
-	{% else -%}
-	ruff check --fix
-	ruff format
-	{% endif %}
+	$(RUN_PREFIX) ruff check --fix
+	$(RUN_PREFIX) ruff format
 {% elif cookiecutter.linting_and_formatting == 'flake8+black+isort' %}
 ## Lint using flake8, black, and isort (use `make format` to do formatting)
 .PHONY: lint
 lint:
-	{% if cookiecutter.environment_manager == 'uv' -%}
-	uv run flake8 {{ cookiecutter.module_name }}
-	uv run isort --check --diff {{ cookiecutter.module_name }}
-	uv run black --check {{ cookiecutter.module_name }}
-	{% elif cookiecutter.environment_manager == 'poetry' -%}
-	poetry run flake8 {{ cookiecutter.module_name }}
-	poetry run isort --check --diff {{ cookiecutter.module_name }}
-	poetry run black --check {{ cookiecutter.module_name }}
-	{% elif cookiecutter.environment_manager == 'pixi' -%}
-	pixi run flake8 {{ cookiecutter.module_name }}
-	pixi run isort --check --diff {{ cookiecutter.module_name }}
-	pixi run black --check {{ cookiecutter.module_name }}
-	{% else -%}
-	flake8 {{ cookiecutter.module_name }}
-	isort --check --diff {{ cookiecutter.module_name }}
-	black --check {{ cookiecutter.module_name }}
-	{% endif %}
+	$(RUN_PREFIX) flake8 {{ cookiecutter.module_name }}
+	$(RUN_PREFIX) isort --check --diff {{ cookiecutter.module_name }}
+	$(RUN_PREFIX) black --check {{ cookiecutter.module_name }}
 
 ## Format source code with black
 .PHONY: format
 format:
-	{% if cookiecutter.environment_manager == 'uv' -%}
-	uv run isort {{ cookiecutter.module_name }}
-	uv run black {{ cookiecutter.module_name }}
-	{% elif cookiecutter.environment_manager == 'poetry' -%}
-	poetry run isort {{ cookiecutter.module_name }}
-	poetry run black {{ cookiecutter.module_name }}
-	{% elif cookiecutter.environment_manager == 'pixi' -%}
-	pixi run isort {{ cookiecutter.module_name }}
-	pixi run black {{ cookiecutter.module_name }}
-	{% else -%}
-	isort {{ cookiecutter.module_name }}
-	black {{ cookiecutter.module_name }}
-	{% endif %}
+	$(RUN_PREFIX) isort {{ cookiecutter.module_name }}
+	$(RUN_PREFIX) black {{ cookiecutter.module_name }}
 {% endif %}
 
 ## Run tests
 .PHONY: test
 test:
-	{% if cookiecutter.environment_manager == 'uv' -%}
-	uv run pytest tests
-	{% elif cookiecutter.environment_manager == 'poetry' -%}
-	poetry run pytest tests
-	{% elif cookiecutter.environment_manager == 'pixi' -%}
-	pixi run pytest tests
-	{% else -%}
-	pytest tests
-	{% endif %}
+	$(RUN_PREFIX) pytest tests
 
 {% if cookiecutter.docs == 'mkdocs' %}
 ## Serve documentation with live reload
 .PHONY: docs
 docs:
-	{% if cookiecutter.environment_manager == 'uv' -%}
-	uv run mkdocs serve --livereload
-	{% else -%}
-	mkdocs serve --livereload
-	{% endif %}
+	$(RUN_PREFIX) mkdocs serve --livereload
 
 ## Build documentation
 .PHONY: docs-build
 docs-build:
-	{% if cookiecutter.environment_manager == 'uv' -%}
-	uv run mkdocs build
-	{% else -%}
-	mkdocs build
-	{% endif %}
+	$(RUN_PREFIX) mkdocs build
 {% endif %}
 
 {% if cookiecutter.environment_manager != 'none' %}
@@ -182,15 +145,7 @@ create_environment:
 ## Make dataset
 .PHONY: data
 data: requirements
-	{% if cookiecutter.environment_manager == 'uv' -%}
-	uv run python {{ cookiecutter.module_name }}/dataset.py
-	{% elif cookiecutter.environment_manager == 'poetry' -%}
-	poetry run python {{ cookiecutter.module_name }}/dataset.py
-	{% elif cookiecutter.environment_manager == 'pixi' -%}
-	pixi run python {{ cookiecutter.module_name }}/dataset.py
-	{% else -%}
 	$(PYTHON_INTERPRETER) {{ cookiecutter.module_name }}/dataset.py
-	{% endif %}
 {% endif %}
 
 #################################################################################

--- a/{{ cookiecutter.repo_name }}/README.md
+++ b/{{ cookiecutter.repo_name }}/README.md
@@ -38,7 +38,26 @@ Copy badges from badges.toml and paste them above to customize your README.
 {% if cookiecutter.environment_manager != "none" %}- {{cookiecutter.environment_manager}} for environment management
 {% endif %}- [List any other required software, APIs, or system dependencies]
 
-### Installation
+### Quick Setup
+
+Use the automated setup script to initialize your repository:
+
+```bash
+make setup
+```
+
+This script will:
+
+- Initialize git repository with default branch
+- Configure git remote ({{cookiecutter.repository_url}})
+- Set up your Python environment
+- Install all dependencies
+- Install pre-commit hooks
+- Create an initial commit
+
+### Manual Installation
+
+Alternatively, set up manually:
 
 1. Clone this repository:
 

--- a/{{ cookiecutter.repo_name }}/docs/content/contributing.md
+++ b/{{ cookiecutter.repo_name }}/docs/content/contributing.md
@@ -65,14 +65,12 @@ This project follows NHS England RAP (Reproducible Analytical Pipeline) principl
    ```bash
    python -m venv venv
    source venv/bin/activate
-   pip install -r requirements.txt
    pip install -e .
    ```
 
 {% else %}
 
    ```bash
-   pip install -r requirements.txt
    pip install -e .
    ```
 

--- a/{{ cookiecutter.repo_name }}/docs/content/getting_started.md
+++ b/{{ cookiecutter.repo_name }}/docs/content/getting_started.md
@@ -31,7 +31,26 @@ This project comes pre-configured with:
 
 All dependencies are managed through {% if cookiecutter.environment_manager == "conda" %}`environment.yml`{% else %}`pyproject.toml`{% endif %}, ensuring reproducible installations.
 
-## Installation
+## Quick Setup
+
+The easiest way to set up this project is using the automated setup script:
+
+```bash
+make setup
+```
+
+This script will:
+
+- Initialize git repository with default branch
+- Configure git remote ({{ cookiecutter.repository_url }})
+- Set up your Python environment
+- Install all dependencies
+- Install pre-commit hooks
+- Create an initial commit
+
+## Manual Installation
+
+If you prefer manual setup or need to run individual steps:
 
 {% if cookiecutter.environment_manager == 'conda' %}
 

--- a/{{ cookiecutter.repo_name }}/scripts/setup_repository.py
+++ b/{{ cookiecutter.repo_name }}/scripts/setup_repository.py
@@ -1,0 +1,639 @@
+#!/usr/bin/env python3
+"""Repository setup script for {{ cookiecutter.project_name }}.
+
+This script automates the initial setup of the repository including:
+- Git initialization and remote configuration
+- Python environment setup
+- Dependency installation
+- Pre-commit hook installation
+- Initial commit creation
+
+Run this script after generating the project from the cookiecutter template.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from textwrap import dedent
+
+
+# ANSI color codes for terminal output
+class Colors:
+    """ANSI color codes for terminal output."""
+    GREEN = "\033[92m"
+    YELLOW = "\033[93m"
+    RED = "\033[91m"
+    BLUE = "\033[94m"
+    BOLD = "\033[1m"
+    RESET = "\033[0m"
+
+
+# Status tracking for setup steps
+class SetupStatus:
+    """Track status of each setup step."""
+    def __init__(self):
+        self.git_init = "not_run"
+        self.git_remote = "not_run"
+        self.remote_accessible = False
+        self.environment = "not_run"
+        self.dependencies = "not_run"
+        self.precommit = "not_run"
+        self.initial_commit = "not_run"
+
+
+status = SetupStatus()
+
+
+class SetupError(Exception):
+    """Raised when setup encounters an error that requires user action."""
+
+
+def run_command(cmd: list[str], capture_output: bool = False) -> subprocess.CompletedProcess:
+    """Run a shell command and return the result.
+
+    Parameters
+    ----------
+    cmd : list[str]
+        Command to run as list of arguments
+    capture_output : bool
+        Whether to capture stdout/stderr instead of displaying
+
+    Returns
+    -------
+    subprocess.CompletedProcess
+        Result of the command execution
+
+    Raises
+    ------
+    subprocess.CalledProcessError
+        If command returns non-zero exit code
+    """
+    print(f"Running: {' '.join(cmd)}")
+    result = subprocess.run(
+        cmd,
+        capture_output=capture_output,
+        text=True,
+        check=True,
+    )
+    return result
+
+
+def check_command_available(cmd: str) -> bool:
+    """Check if a command is available in PATH.
+
+    Parameters
+    ----------
+    cmd : str
+        Command name to check
+
+    Returns
+    -------
+    bool
+        True if command is available, False otherwise
+    """
+    try:
+        subprocess.run(
+            ["which", cmd],
+            capture_output=True,
+            check=True,
+        )
+        return True
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return False
+
+
+def setup_git_repository() -> None:
+    """Initialize git repository if not already initialized."""
+    print(f"\n{Colors.BOLD}=== Git Repository Setup ==={Colors.RESET}")
+
+    if (Path(".git")).exists():
+        print(f"{Colors.YELLOW}✓ Git repository already initialized{Colors.RESET}")
+        status.git_init = "skipped"
+        return
+
+    if not check_command_available("git"):
+        status.git_init = "failed"
+        raise SetupError(
+            "Git is not installed. Please install git:\n"
+            "  Ubuntu/Debian: sudo apt-get install git\n"
+            "  macOS: brew install git\n"
+            "  Windows: https://git-scm.com/download/win"
+        )
+
+    run_command(["git", "init"])
+    run_command(["git", "branch", "-M", "main"])
+    print(f"{Colors.GREEN}✓ Git repository initialized with default branch 'main'{Colors.RESET}")
+    status.git_init = "success"
+
+
+def setup_git_remote() -> None:
+    """Configure git remote if not already set up."""
+    print(f"\n{Colors.BOLD}=== Git Remote Setup ==={Colors.RESET}")
+
+    repository_url = "{{ cookiecutter.repository_url }}"
+
+    # Check if remote already exists
+    try:
+        result = run_command(["git", "remote", "get-url", "origin"], capture_output=True)
+        existing_url = result.stdout.strip()
+
+        if existing_url == repository_url:
+            print(f"{Colors.YELLOW}✓ Remote 'origin' already configured: {repository_url}{Colors.RESET}")
+        else:
+            print(f"{Colors.BLUE}Remote 'origin' exists with different URL: {existing_url}{Colors.RESET}")
+            print(f"Updating to: {repository_url}")
+            run_command(["git", "remote", "set-url", "origin", repository_url])
+            print(f"{Colors.GREEN}✓ Remote 'origin' updated{Colors.RESET}")
+    except subprocess.CalledProcessError:
+        # Remote doesn't exist, add it
+        run_command(["git", "remote", "add", "origin", repository_url])
+        print(f"{Colors.GREEN}✓ Remote 'origin' configured: {repository_url}{Colors.RESET}")
+
+    # Verify remote accessibility
+    print(f"Verifying remote repository accessibility...")
+    try:
+        result = run_command(["git", "ls-remote", "--heads", repository_url], capture_output=True)
+        print(f"✓ Remote repository verified: {repository_url}")
+    except subprocess.CalledProcessError:
+        print()
+        print("!" * 70)
+        print("REMOTE REPOSITORY DOES NOT EXIST YET")
+        print("!" * 70)
+        repo_name = repository_url.split('/')[-1]
+        print(dedent(f"""
+            The remote repository has not been created yet: {repository_url}
+            
+            This is normal for new projects!
+            
+            ⚠️  BEFORE YOU CAN PUSH, you must:
+            1. Go to your git hosting platform (GitHub/GitLab/etc.)
+            2. Create a new repository called: {repo_name}
+            3. DO NOT initialize it with README, .gitignore, or license
+               (your local repo already has these files)
+            4. Then run: git push -u origin main
+            
+            See the "NEXT STEPS" section below for detailed instructions.
+        """).strip())
+        print("!" * 70)
+        print()
+        status.git_remote = "warning"
+        status.remote_accessible = False
+
+
+def setup_environment() -> None:
+    """Set up Python environment based on environment manager."""
+    print(f"\n{Colors.BOLD}=== Environment Setup ==={Colors.RESET}")
+
+    env_manager = "{{ cookiecutter.environment_manager }}"
+
+    if env_manager == "none":
+        print("No environment manager selected. Skipping environment setup.")
+        print("You will need to manage dependencies manually.")
+        return
+
+    # Check if environment manager is installed
+    if not check_command_available(env_manager):
+        install_instructions = {
+            "uv": "Install uv: curl -LsSf https://astral.sh/uv/install.sh | sh",
+            "conda": "Install conda: https://docs.conda.io/en/latest/miniconda.html",
+            "poetry": "Install poetry: curl -sSL https://install.python-poetry.org | python3 -",
+            "pipenv": "Install pipenv: pip install pipenv",
+            "pixi": "Install pixi: curl -fsSL https://pixi.sh/install.sh | bash",
+            "virtualenv": "Install virtualenv: pip install virtualenv",
+        }
+        instruction = install_instructions.get(env_manager, f"Please install {env_manager}")
+        raise SetupError(dedent(f"""
+            {env_manager} is not installed.
+            {instruction}
+        """).strip())
+
+    print(f"Using environment manager: {env_manager}")
+
+    # Set up environment based on manager
+    if env_manager == "uv":
+        if Path(".venv").exists():
+            print(f"{Colors.YELLOW}→ Virtual environment already exists{Colors.RESET}")
+            status.environment = "skipped"
+        else:
+            run_command(["uv", "venv"])
+            print(f"{Colors.GREEN}✓ Virtual environment created with uv{Colors.RESET}")
+            status.environment = "success"
+
+    elif env_manager == "virtualenv":
+        if Path(".venv").exists():
+            print(f"{Colors.YELLOW}✓ Virtual environment already exists{Colors.RESET}")
+            status.environment = "skipped"
+        else:
+            python_version = "{{ cookiecutter.python_version_number }}"
+            run_command(["virtualenv", "venv", f"--python=python{python_version}"])
+            print(f"{Colors.GREEN}✓ Virtual environment created with Python {python_version}{Colors.RESET}")
+            status.environment = "success"
+
+    elif env_manager == "conda":
+        env_name = "{{ cookiecutter.repo_name }}"
+        result = subprocess.run(
+            ["conda", "env", "list"], 
+            capture_output=True, 
+            text=True
+        )
+        if env_name in result.stdout:
+            print(f"{Colors.YELLOW}✓ Conda environment '{env_name}' already exists{Colors.RESET}")
+            status.environment = "skipped"
+        else:
+            run_command(["conda", "env", "create", "-f", "environment.yml"])
+            print(f"{Colors.GREEN}✓ Conda environment created{Colors.RESET}")
+            status.environment = "success"
+
+    elif env_manager == "poetry":
+        # Check if poetry environment exists
+        result = subprocess.run(
+            ["poetry", "env", "info", "--path"],
+            capture_output=True,
+            text=True
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            print("Poetry environment already exists. Running install to sync dependencies.")
+        else:
+            print("Creating Poetry environment and installing dependencies.")
+        run_command(["poetry", "install"])
+        print(f"{Colors.GREEN}✓ Poetry setup complete{Colors.RESET}")
+        status.environment = "success"
+        status.dependencies = "success"
+        return  # Poetry installs deps automatically
+
+    elif env_manager == "pipenv":
+        # Pipenv doesn't have a simple check, but install is idempotent
+        print("Setting up Pipenv environment and dependencies.")
+        run_command(["pipenv", "install", "--dev"])
+        print(f"{Colors.GREEN}✓ Pipenv setup complete{Colors.RESET}")
+        status.environment = "success"
+        status.dependencies = "success"
+        return  # Pipenv installs deps automatically
+
+    elif env_manager == "pixi":
+        # Pixi install is idempotent
+        print("Setting up Pixi environment and dependencies.")
+        run_command(["pixi", "install"])
+        print(f"{Colors.GREEN}✓ Pixi setup complete{Colors.RESET}")
+        status.environment = "success"
+        status.dependencies = "success"
+        return  # Pixi installs deps automatically
+
+
+def install_dependencies() -> None:
+    """Install project dependencies."""
+    print("\n=== Dependency Installation ===")
+
+    env_manager = "{{ cookiecutter.environment_manager }}"
+
+    # Skip if no environment manager or if already installed by environment setup
+    if env_manager in ["none", "poetry", "pipenv", "pixi"]:
+        return
+
+    if env_manager == "uv":
+        run_command(["uv", "sync", "--all-extras"])
+        print(f"{Colors.GREEN}✓ Dependencies installed with uv (including all extras){Colors.RESET}")
+        status.dependencies = "success"
+
+    elif env_manager == "virtualenv":
+        # Activate and install with pip
+        if sys.platform == "win32":
+            pip_cmd = [".venv/Scripts/pip"]
+        else:
+            pip_cmd = [".venv/bin/pip"]
+        run_command(pip_cmd + ["install", "-e", ".[dev,test,docs]"])
+        print(f"{Colors.GREEN}✓ Dependencies installed with pip (including dev, test, docs extras){Colors.RESET}")
+        status.dependencies = "success"
+
+    elif env_manager == "conda":
+        # Conda dependencies are in environment.yml
+        print(f"{Colors.GREEN}✓ Dependencies installed via conda environment.yml{Colors.RESET}")
+        status.dependencies = "success"
+
+
+def setup_precommit() -> None:
+    """Install pre-commit hooks."""
+    print("\n=== Pre-commit Setup ===")
+
+    env_manager = "{{ cookiecutter.environment_manager }}"
+
+    # Build command based on environment manager
+    if env_manager == "uv":
+        cmd = ["uv", "run", "pre-commit", "install"]
+    elif env_manager == "conda":
+        env_name = "{{ cookiecutter.repo_name }}"
+        cmd = ["conda", "run", "-n", env_name, "pre-commit", "install"]
+    elif env_manager == "poetry":
+        cmd = ["poetry", "run", "pre-commit", "install"]
+    elif env_manager == "pipenv":
+        cmd = ["pipenv", "run", "pre-commit", "install"]
+    elif env_manager == "pixi":
+        cmd = ["pixi", "run", "pre-commit", "install"]
+    elif env_manager == "virtualenv":
+        if sys.platform == "win32":
+            cmd = [".venv/Scripts/pre-commit", "install"]
+        else:
+            cmd = [".venv/bin/pre-commit", "install"]
+    else:
+        print("No environment manager. Attempting to use system pre-commit.")
+        cmd = ["pre-commit", "install"]
+
+    try:
+        run_command(cmd)
+        print(f"{Colors.GREEN}✓ Pre-commit hooks installed successfully{Colors.RESET}")
+        status.precommit = "success"
+    except subprocess.CalledProcessError:
+        print(f"{Colors.RED}✗ Warning: Could not install pre-commit hooks{Colors.RESET}")
+        print("You can install them later with: pre-commit install")
+        status.precommit = "failed"
+
+
+def create_initial_commit() -> None:
+    """Create initial git commit."""
+    print("\n=== Initial Commit ===")
+
+    # Check if there are any commits
+    try:
+        run_command(["git", "rev-parse", "HEAD"], capture_output=True)
+        print(f"{Colors.YELLOW}\u2713 Repository already has commits{Colors.RESET}")
+        status.initial_commit = "skipped"
+        return
+    except subprocess.CalledProcessError:
+        # No commits yet, create initial commit
+        pass
+
+    # Stage all files first so pre-commit can check them
+    run_command(["git", "add", "."])
+    print("Staged all files")
+
+    print()
+    print("=" * 70)
+    print("RUNNING PRE-COMMIT HOOKS - FAILURES ARE EXPECTED AND NORMAL!")
+    print("=" * 70)
+    print(dedent("""
+        The cookiecutter template generates files with minor formatting issues
+        (trailing whitespace, missing newlines, etc.) that need to be fixed.
+        
+        Pre-commit hooks will now automatically fix these template-generated issues.
+        
+        ⚠️  IMPORTANT: Hooks showing "Failed" is NORMAL and EXPECTED!
+        
+        "Failed" means the hooks found and fixed formatting issues - this is GOOD!
+        
+        The process works like this:
+        1. Hooks check the template-generated files
+        2. Find minor formatting issues (whitespace, newlines, etc.)
+        3. Automatically fix them
+        4. Report "Failed" because they modified files
+        5. We re-stage the fixed files
+        6. Commit again - this time hooks pass because files are clean
+        
+        Don't worry if you see "Failed" messages below - that's the template
+        being cleaned up automatically. It's working correctly!
+    """))
+    print("=" * 70)
+    print()
+
+    env_manager = "{{ cookiecutter.environment_manager }}"
+
+    try:
+        if env_manager == "uv":
+            run_command(["uv", "run", "pre-commit", "run", "--all-files"])
+        elif env_manager == "conda":
+            env_name = "{{ cookiecutter.repo_name }}"
+            run_command(["conda", "run", "-n", env_name, "pre-commit", "run", "--all-files"])
+        elif env_manager == "poetry":
+            run_command(["poetry", "run", "pre-commit", "run", "--all-files"])
+        elif env_manager == "pipenv":
+            run_command(["pipenv", "run", "pre-commit", "run", "--all-files"])
+        elif env_manager == "pixi":
+            run_command(["pixi", "run", "pre-commit", "run", "--all-files"])
+        elif env_manager == "virtualenv":
+            if sys.platform == "win32":
+                run_command([".venv/Scripts/pre-commit", "run", "--all-files"])
+            else:
+                run_command([".venv/bin/pre-commit", "run", "--all-files"])
+        else:
+            run_command(["pre-commit", "run", "--all-files"])
+        print()
+        print("✓ All pre-commit checks passed - files were already clean!")
+        print()
+    except subprocess.CalledProcessError:
+        # Pre-commit fixed files, which is expected and good!
+        print()
+        print("=" * 70)
+        print("✓ Pre-commit hooks automatically fixed formatting issues")
+        print("=" * 70)
+        print("Re-staging fixed files and committing again...")
+        print()
+        run_command(["git", "add", "."])
+
+    # Commit - pre-commit hooks will run again to verify everything is clean
+    run_command(
+        ["git", "commit", "-m", "Initial commit from NHS RAP cookiecutter template"]
+    )
+    print(f"{Colors.GREEN}\u2713 Initial commit created{Colors.RESET}")
+    status.initial_commit = "success"
+
+
+def print_next_steps() -> None:
+    """Print instructions for next steps."""
+    env_manager = "{{ cookiecutter.environment_manager }}"
+    repository_url = "{{ cookiecutter.repository_url }}"
+
+    # Print summary with colors
+    print("\n" + "=" * 70)
+    print(f"{Colors.BOLD}SETUP SUMMARY{Colors.RESET}")
+    print("=" * 70)
+
+    def format_status(step_status: str) -> str:
+        """Format status with color and symbol."""
+        if step_status == "success":
+            return f"{Colors.GREEN}\u2713 Success{Colors.RESET}"
+        elif step_status == "skipped":
+            return f"{Colors.YELLOW}\u2192 Skipped (already exists){Colors.RESET}"
+        elif step_status == "warning":
+            return f"{Colors.YELLOW}\u26a0 Warning{Colors.RESET}"
+        elif step_status == "failed":
+            return f"{Colors.RED}\u2717 Failed{Colors.RESET}"
+        else:
+            return f"{Colors.BLUE}- Not run{Colors.RESET}"
+
+    print(f"\n{Colors.BOLD}Setup Steps:{Colors.RESET}")
+    print(f"  Git repository:      {format_status(status.git_init)}")
+    print(f"  Git remote:          {format_status(status.git_remote)}")
+    if not status.remote_accessible and status.git_remote != "not_run":
+        print(f"                       {Colors.YELLOW}(Remote needs to be created){Colors.RESET}")
+    print(f"  Python environment:  {format_status(status.environment)}")
+    print(f"  Dependencies:        {format_status(status.dependencies)}")
+    print(f"  Pre-commit hooks:    {format_status(status.precommit)}")
+    print(f"  Initial commit:      {format_status(status.initial_commit)}")
+
+    print(f"\n{Colors.BOLD}Overall Status:{Colors.RESET}")
+    if (status.git_init in ["success", "skipped"] and 
+        status.git_remote in ["success", "warning"] and
+        status.environment in ["success", "skipped"] and
+        status.dependencies in ["success", "skipped"] and
+        status.precommit in ["success", "skipped"] and
+        status.initial_commit in ["success", "skipped"]):
+        print(f"  {Colors.GREEN}\u2713 Repository setup complete and ready for development!{Colors.RESET}")
+        if not status.remote_accessible:
+            print(f"  {Colors.YELLOW}\u26a0 Remember to create the remote repository before pushing{Colors.RESET}")
+    else:
+        print(f"  {Colors.YELLOW}\u26a0 Setup partially complete - review steps above{Colors.RESET}")
+
+    # Print next steps
+    print("\n" + "=" * 70)
+    print(f"{Colors.BOLD}NEXT STEPS{Colors.RESET}")
+    print("=" * 70)
+
+    print("\n1. Verify your setup:")
+    if env_manager == "uv":
+        print("   uv run pytest tests/unittests/ -v")
+    elif env_manager == "conda":
+        env_name = "{{ cookiecutter.repo_name }}"
+        print(f"   conda activate {env_name}")
+        print("   pytest tests/unittests/ -v")
+    elif env_manager == "poetry":
+        print("   poetry run pytest tests/unittests/ -v")
+    elif env_manager == "pipenv":
+        print("   pipenv run pytest tests/unittests/ -v")
+    elif env_manager == "pixi":
+        print("   pixi run pytest tests/unittests/ -v")
+    elif env_manager == "virtualenv":
+        print("   source .venv/bin/activate  # On Windows: .venv\\Scripts\\activate")
+        print("   pytest tests/unittests/ -v")
+    else:
+        print("   pytest tests/unittests/ -v")
+
+    if status.git_remote in ["success", "warning"]:
+        if status.remote_accessible:
+            print("\n2. Push to remote repository:")
+            print("   git push -u origin main")
+        else:
+            repo_name = repository_url.split('/')[-1]
+            base_url = '/'.join(repository_url.split('/')[:-1])
+            print(dedent(f"""
+                2. Create the remote repository (if it doesn't exist yet):
+                   a) Go to your git hosting platform: {base_url}
+                   b) Click "New repository" or "Create new project"
+                   c) Name it: {repo_name}
+                   d) DO NOT initialize with README, .gitignore, or license
+                      (your local repo already has these)
+                   
+                   Then push your code:
+                   git push -u origin main
+                   
+                   If the remote URL is different, update it:
+                   git remote set-url origin <correct-url>
+            """).strip())
+
+    print(f"\n3. Repository URL: {repository_url}")
+
+    print(dedent("""
+        4. Review the documentation:
+           - README.md: Project overview and quick start
+           - CONTRIBUTING.md: How to contribute
+           - OPEN_CODE_CHECKLIST.md: Checklist before publishing code
+    """).strip())
+
+    docs_choice = "{{ cookiecutter.docs }}"
+    if docs_choice == "mkdocs":
+        print("\n5. Build and view documentation:")
+        if env_manager == "uv":
+            print("   uv run mkdocs serve")
+        elif env_manager == "conda":
+            print("   conda activate {{ cookiecutter.repo_name }}")
+            print("   mkdocs serve")
+        elif env_manager == "poetry":
+            print("   poetry run mkdocs serve")
+        elif env_manager == "pipenv":
+            print("   pipenv run mkdocs serve")
+        elif env_manager == "pixi":
+            print("   pixi run mkdocs serve")
+        else:
+            print("   mkdocs serve")
+        print("   Then visit: http://127.0.0.1:8000")
+
+    print("\n" + "=" * 70)
+
+
+def main() -> None:
+    """Run the repository setup process."""
+    print("NHS RAP Repository Setup")
+    print("=" * 50)
+    print("Project: {{ cookiecutter.project_name }}")
+    print("Repository: {{ cookiecutter.repository_url }}")
+    print("=" * 50)
+
+    try:
+        # Step 1: Git initialization
+        try:
+            setup_git_repository()
+        except SetupError as e:
+            print(f"{Colors.RED}\u2717 Git setup failed: {e}{Colors.RESET}")
+            status.git_init = "failed"
+        except subprocess.CalledProcessError as e:
+            print(f"{Colors.RED}\u2717 Git setup command failed: {' '.join(e.cmd)}{Colors.RESET}")
+            status.git_init = "failed"
+
+        # Step 2: Git remote setup
+        try:
+            setup_git_remote()
+        except SetupError as e:
+            print(f"{Colors.RED}\u2717 Git remote setup failed: {e}{Colors.RESET}")
+            status.git_remote = "failed"
+        except subprocess.CalledProcessError as e:
+            print(f"{Colors.RED}\u2717 Git remote command failed: {' '.join(e.cmd)}{Colors.RESET}")
+            status.git_remote = "failed"
+
+        # Step 3: Environment setup - skip remaining steps if this fails
+        try:
+            setup_environment()
+        except SetupError as e:
+            print(f"{Colors.RED}\u2717 Environment setup failed: {e}{Colors.RESET}")
+            print(f"{Colors.YELLOW}Skipping remaining steps that require the environment{Colors.RESET}")
+            status.environment = "failed"
+            print_next_steps()
+            return
+        except subprocess.CalledProcessError as e:
+            print(f"{Colors.RED}\u2717 Environment command failed: {' '.join(e.cmd)}{Colors.RESET}")
+            print(f"{Colors.YELLOW}Skipping remaining steps that require the environment{Colors.RESET}")
+            status.environment = "failed"
+            print_next_steps()
+            return
+
+        # Step 4: Dependencies
+        try:
+            install_dependencies()
+        except subprocess.CalledProcessError as e:
+            print(f"{Colors.RED}\u2717 Dependency installation failed: {' '.join(e.cmd)}{Colors.RESET}")
+            status.dependencies = "failed"
+
+        # Step 5: Pre-commit hooks
+        try:
+            setup_precommit()
+        except subprocess.CalledProcessError as e:
+            print(f"{Colors.RED}\u2717 Pre-commit setup failed: {' '.join(e.cmd)}{Colors.RESET}")
+            status.precommit = "failed"
+
+        # Step 6: Initial commit
+        try:
+            create_initial_commit()
+        except subprocess.CalledProcessError as e:
+            print(f"{Colors.RED}\u2717 Initial commit failed: {' '.join(e.cmd)}{Colors.RESET}")
+            status.initial_commit = "failed"
+
+        # Always show next steps
+        print_next_steps()
+
+    except KeyboardInterrupt:
+        print(f"\n{Colors.YELLOW}Setup interrupted by user{Colors.RESET}", file=sys.stderr)
+        print_next_steps()
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

This PR implements automated repository setup and comprehensively fixes documentation inaccuracies.

## Changes

### Features (Implements #6, #7, #13)
- ✅ Add `scripts/setup_repository.py` for automated repository initialization
  - Initialize git repository with default branch
  - Configure git remote with verification
  - Set up Python environment for all supported managers (uv, conda, poetry, pipenv, pixi, virtualenv, none)
  - Install dependencies with `--all-extras`
  - Install and run pre-commit hooks
  - Create initial commit (with pre-commit fixes applied)
  - Colored terminal output with status tracking
  - Graceful error handling with detailed summary
- ✅ Add `make setup` command as primary entry point
- ✅ Add comprehensive test coverage (15 + 13 tests)

### Refactoring
- ✅ Simplify Makefile with `PYTHON_INTERPRETER` and `RUN_PREFIX` variables
  - Remove 100+ lines of repetitive conditional blocks
  - All make targets now use consistent variable-based commands
  - Support all environment managers automatically

### Documentation Fixes (Addresses #35)
- ✅ Fix configuration options table
  - Add missing `git_hosting_platform` option (github, gitlab, azure_devops, other)
  - Add missing `repository_url` option (users can override default)
  - Add `repo_name` and `module_name` (users can override computed defaults)
  - Fix license options: MIT, Apache-2.0, GPL-3.0, No license file (not BSD-3-Clause)
  - Fix `include_code_scaffold` case: Yes, No (not yes, no)
  - Clarify `organization_name` is not fixed, just defaults to NHS England
- ✅ Fix project structure diagrams
  - Fix test directories: `unittests/` and `e2e/` (not pytest/ and unittest/)
  - Add missing `scripts/` directory with `setup_repository.py`
  - Add missing files: badges.toml, .env, CODE_OF_CONDUCT.md, LICENSE-OGL, setup.cfg
- ✅ Make documentation environment-manager agnostic
  - Add mkdocs tabbed sections for UV, Conda, Poetry, Pipenv, Pixi
  - Emphasize `make setup` as primary workflow
  - Remove non-existent `requirements.txt` references
- ✅ Document `badges.toml` as copy/paste badge library
- ✅ Add tox documentation for testing across Python versions
- ✅ Fix CONTRIBUTING.md list numbering bug

## Testing
- ✅ All 139 tests pass (126 original + 13 new)
- ✅ Tested with uv and poetry environment managers
- ✅ Pre-commit hooks pass on all commits
- ✅ Tox tests pass across Python 3.10-3.13

## Issues Closed
Closes #6
Closes #7
Closes #13
Addresses #35