### PR TITLE
Fix macOS compatibility issues (#50, #51)

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -11,7 +11,6 @@
     "repository_url": "https://github.com/{{ cookiecutter.organization_name.lower().replace(' ', '') }}/{{ cookiecutter.repo_name }}",
     "description": "A short description of the project.",
     "python_version_number": ["3.10", "3.11", "3.12", "3.13"],
-    "year": "{% now 'utc', '%Y' %}",
     "environment_manager": [
         "uv",
         "virtualenv",

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -2,14 +2,11 @@
 """Post-generation hook to rename template files and clean up unused configuration."""
 
 import warnings
+from datetime import datetime
 from pathlib import Path
 
-# Get the current year from cookiecutter context
-year = "{{ cookiecutter.year }}"
-
-# Validate year format
-if not year.isdigit() or len(year) != 4:
-    raise ValueError(f"Invalid year value: '{year}'. Expected 4-digit year.")
+# Compute the current year from Python's datetime (avoids jinja2-time dependency)
+year = str(datetime.now().year)
 
 # Replace year placeholder in all template files
 PLACEHOLDER = "@YEAR_PLACEHOLDER@"

--- a/{{ cookiecutter.repo_name }}/.pre-commit-config.yaml
+++ b/{{ cookiecutter.repo_name }}/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
       - id: ruff-format
   # Clear Jupyter notebook outputs
   - repo: https://github.com/kynan/nbstripout
-    rev: 0.8.1
+    rev: v0.9.0
     hooks:
       - id: nbstripout
   # Additional helpful hooks

--- a/{{ cookiecutter.repo_name }}/Makefile
+++ b/{{ cookiecutter.repo_name }}/Makefile
@@ -115,8 +115,10 @@ create_environment:
 	conda env create --name $(PROJECT_NAME) -f environment.yml
 	@echo ">>> conda env created. Activate with:\nconda activate $(PROJECT_NAME)"
 	{% elif cookiecutter.environment_manager == 'virtualenv' -%}
-	@bash -c "if [ ! -z `which virtualenvwrapper.sh` ]; then source `which virtualenvwrapper.sh`; mkvirtualenv $(PROJECT_NAME) --python=$(PYTHON_INTERPRETER); else mkvirtualenv.bat $(PROJECT_NAME) --python=$(PYTHON_INTERPRETER); fi"
-	@echo ">>> New virtualenv created. Activate with:\nworkon $(PROJECT_NAME)"
+	virtualenv .venv --python=python$(PYTHON_VERSION)
+	@echo ">>> New virtualenv created. Activate with:"
+	@echo ">>> Unix/macOS: source .venv/bin/activate"
+	@echo ">>> Windows:    .venv\\Scripts\\activate"
 	{% elif cookiecutter.environment_manager == 'pipenv' -%}
 	pipenv --python $(PYTHON_VERSION)
 	@echo ">>> New pipenv created. Activate with:\npipenv shell"

--- a/{{ cookiecutter.repo_name }}/mkdocs.yml
+++ b/{{ cookiecutter.repo_name }}/mkdocs.yml
@@ -74,7 +74,7 @@ extra:
       link: mailto:{{ cookiecutter.team_email }}{% endif %}
   generator: false
 
-copyright: Copyright &copy; {% now 'utc', '%Y' %} Crown Copyright ({{ cookiecutter.organization_name }})
+copyright: Copyright &copy; @YEAR_PLACEHOLDER@ Crown Copyright ({{ cookiecutter.organization_name }})
 
 markdown_extensions:
   - tables

--- a/{{ cookiecutter.repo_name }}/models/model_card_template.md
+++ b/{{ cookiecutter.repo_name }}/models/model_card_template.md
@@ -11,7 +11,7 @@ This section contains top-level information about what the model is. The details
 | **Description:** | [General overview of the model, what it does, and motivation for developing it. No more than one paragraph] |
 | **Model Type:** | [Specify the type of model (e.g., clustering, time series, deep learning models, reinforcement learning, supervised learning, ensemble, hybrid, etc.) and describe its main characteristics] |
 | **Developed By:** | {{ cookiecutter.author_name }} / {{ cookiecutter.team_name }} |
-| **Launch Date:** | [Expected or Launch Date - e.g., {% now 'utc', '%B %Y' %}] |
+| **Launch Date:** | [Expected or Launch Date - e.g., @YEAR_PLACEHOLDER@] |
 | **Version** | [As in model registry - e.g., 1.0.0] |
 
 ## Intended Use


### PR DESCRIPTION
Fixes #50 and #51.

Two bugs that prevent the cookiecutter from working correctly on macOS.

- Remove `jinja2-time` dependency from template rendering; year is now computed in the post-generation hook via `datetime.now().year`
- Fix `make create_environment` for `virtualenv` to use a direct cross-platform `virtualenv .venv` call instead of a `bash` conditional that fell through to `mkvirtualenv.bat` on macOS/Linux

Also bumps `nbstripout` to `v0.9.0`.