### PR TITLE
fix: resolve template correctness bugs and add regression test suite

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,35 +90,26 @@ cookiecutter . --no-input
 
 ### Dynamic Year Values
 
-Always use dynamic year values instead of hardcoding them. The approach depends on whether the file is processed by cookiecutter or by MkDocs:
+Always use `@YEAR_PLACEHOLDER@` in template files — never hardcode a year and never use
+the `{% now %}` Jinja2 extension (it was removed from cookiecutter in v2.3+).
 
-**For cookiecutter-processed files** (e.g., LICENSE, Python files):
+The post-generation hook (`hooks/post_gen_project.py`) replaces every occurrence of
+`@YEAR_PLACEHOLDER@` with the current year at project-generation time. This works across
+all file types, including copy-without-render files such as `*.html`.
 
-```jinja
-{# CORRECT - Processed by cookiecutter during generation #}
-Copyright (c) {% now 'utc', '%Y' %} NHS England
-
-{# WRONG - Hardcoded year #}
-Copyright (c) 2026 NHS England
+```text
+CORRECT  →  Copyright (c) @YEAR_PLACEHOLDER@ NHS England
+WRONG    →  Copyright (c) 2026 NHS England          (hardcoded)
+WRONG    →  Copyright (c) {% now 'utc', '%Y' %}     (removed extension)
 ```
 
-**For MkDocs template files** (e.g., footer.html):
+**Files using `@YEAR_PLACEHOLDER@`:**
 
-```jinja
-{# CORRECT - Evaluated by MkDocs at build time #}
-&copy; {{ "now().year" }} Crown Copyright (NHS England)
-
-{# WRONG - Hardcoded year #}
-&copy; 2026 Crown Copyright (NHS England)
-```
-
-This ensures generated projects always display the current year without manual updates.
-
-**Files using dynamic years:**
-
-- `{{ cookiecutter.repo_name }}/LICENSE` - Uses cookiecutter's `{% now 'utc', '%Y' %}`
-- `{{ cookiecutter.repo_name }}/docs/content/overrides/partials/footer.html` - Uses MkDocs' `{{ "now().year" }}`
-- `docs/overrides/partials/footer.html` - Cookiecutter repo footer, uses MkDocs' `{{ "now().year" }}`
+- `{{ cookiecutter.repo_name }}/LICENSE`
+- `{{ cookiecutter.repo_name }}/mkdocs.yml`
+- `{{ cookiecutter.repo_name }}/docs/content/overrides/partials/footer.html`
+- `{{ cookiecutter.repo_name }}/README.md`
+- `{{ cookiecutter.repo_name }}/docs/content/index.md`
 
 ## Making Changes
 

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -11,7 +11,6 @@
     "repository_url": "https://github.com/{{ cookiecutter.organization_name.lower().replace(' ', '') }}/{{ cookiecutter.repo_name }}",
     "description": "A short description of the project.",
     "python_version_number": ["3.10", "3.11", "3.12", "3.13"],
-    "year": "{% now 'utc', '%Y' %}",
     "environment_manager": [
         "uv",
         "virtualenv",
@@ -31,7 +30,6 @@
     "_copy_without_render": [
         "*.html",
         "*.css",
-        "*.js",
-        "LICENSE"
+        "*.js"
     ]
 }

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -3,10 +3,10 @@
 
 import shutil
 import warnings
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
-year = str(datetime.now().year)
+year = str(datetime.now(timezone.utc).year)
 
 # Replace year placeholder in all template files
 PLACEHOLDER = "@YEAR_PLACEHOLDER@"

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -1,15 +1,12 @@
 #!/usr/bin/env python3
 """Post-generation hook to rename template files and clean up unused configuration."""
 
+import shutil
 import warnings
+from datetime import datetime
 from pathlib import Path
 
-# Get the current year from cookiecutter context
-year = "{{ cookiecutter.year }}"
-
-# Validate year format
-if not year.isdigit() or len(year) != 4:
-    raise ValueError(f"Invalid year value: '{year}'. Expected 4-digit year.")
+year = str(datetime.now().year)
 
 # Replace year placeholder in all template files
 PLACEHOLDER = "@YEAR_PLACEHOLDER@"
@@ -23,7 +20,6 @@ for file_path in repo_root.rglob("*"):
                 content = content.replace(PLACEHOLDER, year)
                 file_path.write_text(content, encoding="utf-8")
         except (UnicodeDecodeError, PermissionError):
-            # Skip binary files and files we can't read
             pass
         except Exception as e:
             warnings.warn(f"Failed to update year in {file_path}: {e}", stacklevel=2)
@@ -41,8 +37,6 @@ if env_file.exists():
 # Determine which dependency file to keep based on environment manager
 env_manager = "{{ cookiecutter.environment_manager }}"
 
-# Mapping of environment manager to dependency file
-# Most use pyproject.toml, only conda needs environment.yml
 dependency_files = {
     "virtualenv": "_pyproject.toml",
     "uv": "_pyproject.toml",
@@ -74,3 +68,33 @@ if linting_choice == "ruff":
     setup_cfg = Path("setup.cfg")
     if setup_cfg.exists():
         setup_cfg.unlink()
+
+# Remove docs and mkdocs config when docs are not enabled
+docs_choice = "{{ cookiecutter.docs }}"
+if docs_choice != "mkdocs":
+    docs_dir = Path("docs")
+    if docs_dir.exists():
+        shutil.rmtree(docs_dir)
+    mkdocs_config = Path("mkdocs.yml")
+    if mkdocs_config.exists():
+        mkdocs_config.unlink()
+
+# Remove code scaffold when disabled
+include_scaffold = "{{ cookiecutter.include_code_scaffold }}"
+if include_scaffold != "Yes":
+    module_dir = Path("{{ cookiecutter.module_name }}")
+    if module_dir.exists():
+        shutil.rmtree(module_dir)
+    example_test = Path("tests") / "unittests" / "test_data.py"
+    if example_test.exists():
+        example_test.unlink()
+    model_card = Path("models") / "model_card_template.md"
+    if model_card.exists():
+        model_card.unlink()
+
+# Remove LICENSE when no license is chosen
+license_choice = "{{ cookiecutter.open_source_license }}"
+if license_choice == "No license file":
+    license_file = Path("LICENSE")
+    if license_file.exists():
+        license_file.unlink()

--- a/tests/test_no_leftover_markers.py
+++ b/tests/test_no_leftover_markers.py
@@ -63,11 +63,22 @@ class TestNoLeftoverMarkers:
         )
 
     def test_no_jinja_markers_in_text_files(self, cookies, config_name, context):
-        """No raw {{ or {% markers remain in rendered text files."""
+        """No raw {{ or {% markers remain in rendered text files.
+
+        Files under .github/ are excluded: GitHub Actions workflows legitimately
+        use ${{ }} expression syntax which contains {{ but is not a Jinja marker.
+        """
         result = cookies.bake(extra_context=context)
         assert result.exit_code == 0
 
+        github_dir = result.project_path / ".github"
         for file_path in _text_files(result.project_path):
+            try:
+                # Skip .github/ — GitHub Actions ${{ }} syntax is not a Jinja marker
+                file_path.relative_to(github_dir)
+                continue
+            except ValueError:
+                pass
             try:
                 content = file_path.read_text(encoding="utf-8")
             except (UnicodeDecodeError, PermissionError):
@@ -100,6 +111,9 @@ class TestNoLeftoverMarkers:
             assert not (result.project_path / name).exists(), (
                 f"[{config_name}] '{name}' should have been renamed/removed by hook"
             )
+        assert not (result.project_path / "_data").exists(), (
+            f"[{config_name}] '_data/' should have been renamed to 'data/' by hook"
+        )
 
     def test_docs_removed_when_docs_none(self, cookies, config_name, context):
         """docs/ directory and mkdocs.yml are absent when docs=none."""

--- a/tests/test_no_leftover_markers.py
+++ b/tests/test_no_leftover_markers.py
@@ -1,0 +1,166 @@
+"""Regression tests: no unrendered Jinja markers or stale placeholders in baked projects."""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+CONFIGS_PATH = Path(__file__).parent.parent / "scripts" / "configs.yaml"
+
+# Keys that exist in cookiecutter.json; extras in configs.yaml are filtered out
+COOKIECUTTER_KEYS = {
+    "project_name",
+    "repo_name",
+    "module_name",
+    "author_name",
+    "author_email",
+    "organization_name",
+    "team_name",
+    "team_email",
+    "git_hosting_platform",
+    "repository_url",
+    "description",
+    "python_version_number",
+    "environment_manager",
+    "linting_and_formatting",
+    "open_source_license",
+    "docs",
+    "include_code_scaffold",
+}
+
+# File extensions where leftover Jinja/placeholder markers would be a bug.
+# Excludes *.html because docs/overrides/ are copy-without-render MkDocs templates.
+CHECKED_EXTENSIONS = {".md", ".toml", ".yaml", ".yml", ".cfg", ".py", ".txt", ".env"}
+
+
+def load_configs() -> list[tuple[str, dict]]:
+    with open(CONFIGS_PATH) as f:
+        raw = yaml.safe_load(f)
+    return [
+        (name, {k: v for k, v in cfg.items() if k in COOKIECUTTER_KEYS})
+        for name, cfg in raw.items()
+    ]
+
+
+CONFIGS = load_configs()
+
+
+def _text_files(project_path: Path):
+    for p in project_path.rglob("*"):
+        if p.is_file() and p.suffix in CHECKED_EXTENSIONS:
+            yield p
+
+
+@pytest.mark.parametrize("config_name,context", CONFIGS)
+class TestNoLeftoverMarkers:
+    """Bake every config and verify no unrendered markers remain."""
+
+    def test_bakes_successfully(self, cookies, config_name, context):
+        """Template bakes without errors for this configuration."""
+        result = cookies.bake(extra_context=context)
+        assert result.exit_code == 0, (
+            f"[{config_name}] bake failed with exception: {result.exception}"
+        )
+
+    def test_no_jinja_markers_in_text_files(self, cookies, config_name, context):
+        """No raw {{ or {% markers remain in rendered text files."""
+        result = cookies.bake(extra_context=context)
+        assert result.exit_code == 0
+
+        for file_path in _text_files(result.project_path):
+            try:
+                content = file_path.read_text(encoding="utf-8")
+            except (UnicodeDecodeError, PermissionError):
+                continue
+            rel = file_path.relative_to(result.project_path)
+            assert "{%" not in content, f"[{config_name}] '{{% marker in {rel}"
+            assert "{{" not in content, f"[{config_name}] '{{{{' marker in {rel}"
+
+    def test_no_year_placeholder_in_text_files(self, cookies, config_name, context):
+        """@YEAR_PLACEHOLDER@ is fully replaced in all checked text files."""
+        result = cookies.bake(extra_context=context)
+        assert result.exit_code == 0
+
+        for file_path in _text_files(result.project_path):
+            try:
+                content = file_path.read_text(encoding="utf-8")
+            except (UnicodeDecodeError, PermissionError):
+                continue
+            rel = file_path.relative_to(result.project_path)
+            assert "@YEAR_PLACEHOLDER@" not in content, (
+                f"[{config_name}] '@YEAR_PLACEHOLDER@' not replaced in {rel}"
+            )
+
+    def test_no_underscore_prefixed_files_remain(self, cookies, config_name, context):
+        """Underscore-prefixed staging files are renamed/removed by the hook."""
+        result = cookies.bake(extra_context=context)
+        assert result.exit_code == 0
+
+        for name in ["_.env", "_pyproject.toml", "_environment.yml"]:
+            assert not (result.project_path / name).exists(), (
+                f"[{config_name}] '{name}' should have been renamed/removed by hook"
+            )
+
+    def test_docs_removed_when_docs_none(self, cookies, config_name, context):
+        """docs/ directory and mkdocs.yml are absent when docs=none."""
+        if context.get("docs", "mkdocs") != "none":
+            pytest.skip("docs != none — skipping")
+        result = cookies.bake(extra_context=context)
+        assert result.exit_code == 0
+
+        assert not (result.project_path / "docs").exists(), (
+            f"[{config_name}] 'docs/' should be removed when docs=none"
+        )
+        assert not (result.project_path / "mkdocs.yml").exists(), (
+            f"[{config_name}] 'mkdocs.yml' should be removed when docs=none"
+        )
+
+    def test_module_scaffold_removed_when_disabled(self, cookies, config_name, context):
+        """Python module directory is absent when include_code_scaffold=No."""
+        if context.get("include_code_scaffold", "Yes") != "No":
+            pytest.skip("include_code_scaffold != No — skipping")
+        result = cookies.bake(extra_context=context)
+        assert result.exit_code == 0
+
+        module_name = context.get("module_name") or (
+            context.get("project_name", "project_name").lower().replace(" ", "_").replace("-", "_")
+        )
+        assert not (result.project_path / module_name).exists(), (
+            f"[{config_name}] '{module_name}/' should be removed when include_code_scaffold=No"
+        )
+
+    def test_license_removed_when_no_license_chosen(self, cookies, config_name, context):
+        """LICENSE file is absent when open_source_license='No license file'."""
+        if context.get("open_source_license", "MIT") != "No license file":
+            pytest.skip("open_source_license != 'No license file' — skipping")
+        result = cookies.bake(extra_context=context)
+        assert result.exit_code == 0
+
+        assert not (result.project_path / "LICENSE").exists(), (
+            f"[{config_name}] 'LICENSE' should be removed when 'No license file' is chosen"
+        )
+
+    def test_license_contains_only_chosen_license(self, cookies, config_name, context):
+        """LICENSE file contains only the selected licence text (no raw Jinja blocks)."""
+        # Maps SPDX identifier → a unique phrase found in that licence body
+        license_phrases = {
+            "MIT": "MIT License",
+            "Apache-2.0": "Apache License",
+            "GPL-3.0": "GNU GENERAL PUBLIC LICENSE",
+        }
+        license_choice = context.get("open_source_license", "MIT")
+        if license_choice == "No license file":
+            pytest.skip("No license file — skipping")
+        result = cookies.bake(extra_context=context)
+        assert result.exit_code == 0
+
+        license_path = result.project_path / "LICENSE"
+        assert license_path.exists(), f"[{config_name}] LICENSE file missing"
+        content = license_path.read_text()
+        # Raw Jinja conditionals must not be present
+        assert "{%" not in content, f"[{config_name}] Raw Jinja found in LICENSE"
+        # The correct licence body text should appear
+        expected_phrase = license_phrases.get(license_choice, license_choice)
+        assert expected_phrase in content, (
+            f"[{config_name}] '{expected_phrase}' not found in LICENSE for {license_choice}"
+        )

--- a/{{ cookiecutter.repo_name }}/.pre-commit-config.yaml
+++ b/{{ cookiecutter.repo_name }}/.pre-commit-config.yaml
@@ -1,6 +1,7 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
+{% if cookiecutter.linting_and_formatting == 'ruff' %}
   # Ruff for linting and formatting
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.14.3
@@ -10,6 +11,24 @@ repos:
         args: [--fix]
       # Run the formatter
       - id: ruff-format
+{% elif cookiecutter.linting_and_formatting == 'flake8+black+isort' %}
+  # Flake8 for linting
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.1.1
+    hooks:
+      - id: flake8
+  # Black for formatting
+  - repo: https://github.com/psf/black
+    rev: 24.10.0
+    hooks:
+      - id: black
+  # isort for import sorting
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+        args: ["--profile", "black"]
+{% endif %}
   # Clear Jupyter notebook outputs
   - repo: https://github.com/kynan/nbstripout
     rev: 0.8.1

--- a/{{ cookiecutter.repo_name }}/Makefile
+++ b/{{ cookiecutter.repo_name }}/Makefile
@@ -63,6 +63,11 @@ clean:
 	find . -type f -name "*.py[co]" -delete
 	find . -type d -name "__pycache__" -delete
 
+## Update pre-commit hooks to their latest versions
+.PHONY: hooks-update
+hooks-update:
+	$(RUN_PREFIX) pre-commit autoupdate
+
 {% if cookiecutter.linting_and_formatting == 'ruff' %}
 ## Lint using ruff (use `make format` to do formatting)
 .PHONY: lint
@@ -115,8 +120,11 @@ create_environment:
 	conda env create --name $(PROJECT_NAME) -f environment.yml
 	@echo ">>> conda env created. Activate with:\nconda activate $(PROJECT_NAME)"
 	{% elif cookiecutter.environment_manager == 'virtualenv' -%}
-	@bash -c "if [ ! -z `which virtualenvwrapper.sh` ]; then source `which virtualenvwrapper.sh`; mkvirtualenv $(PROJECT_NAME) --python=$(PYTHON_INTERPRETER); else mkvirtualenv.bat $(PROJECT_NAME) --python=$(PYTHON_INTERPRETER); fi"
-	@echo ">>> New virtualenv created. Activate with:\nworkon $(PROJECT_NAME)"
+	python -m venv .venv
+	@echo ">>> New virtualenv created at .venv"
+	@echo ">>> Activate with:"
+	@echo ">>> Windows: .\\.venv\\Scripts\\activate"
+	@echo ">>> Unix/macOS: source ./.venv/bin/activate"
 	{% elif cookiecutter.environment_manager == 'pipenv' -%}
 	pipenv --python $(PYTHON_VERSION)
 	@echo ">>> New pipenv created. Activate with:\npipenv shell"

--- a/{{ cookiecutter.repo_name }}/mkdocs.yml
+++ b/{{ cookiecutter.repo_name }}/mkdocs.yml
@@ -74,7 +74,7 @@ extra:
       link: mailto:{{ cookiecutter.team_email }}{% endif %}
   generator: false
 
-copyright: Copyright &copy; {% now 'utc', '%Y' %} Crown Copyright ({{ cookiecutter.organization_name }})
+copyright: Copyright &copy; @YEAR_PLACEHOLDER@ Crown Copyright ({{ cookiecutter.organization_name }})
 
 markdown_extensions:
   - tables

--- a/{{ cookiecutter.repo_name }}/models/model_card_template.md
+++ b/{{ cookiecutter.repo_name }}/models/model_card_template.md
@@ -11,7 +11,7 @@ This section contains top-level information about what the model is. The details
 | **Description:** | [General overview of the model, what it does, and motivation for developing it. No more than one paragraph] |
 | **Model Type:** | [Specify the type of model (e.g., clustering, time series, deep learning models, reinforcement learning, supervised learning, ensemble, hybrid, etc.) and describe its main characteristics] |
 | **Developed By:** | {{ cookiecutter.author_name }} / {{ cookiecutter.team_name }} |
-| **Launch Date:** | [Expected or Launch Date - e.g., {% now 'utc', '%B %Y' %}] |
+| **Launch Date:** | [Expected or Launch Date - e.g., @YEAR_PLACEHOLDER@] |
 | **Version** | [As in model registry - e.g., 1.0.0] |
 
 ## Intended Use


### PR DESCRIPTION
Fixes #50 (jinja2-time/{% now %} removed from cookiecutter >=2.3):
- Remove the 'year' variable from cookiecutter.json; hook now computes
  the year directly via datetime.now().year
- Replace all {% now %} usages in mkdocs.yml and model_card_template.md
  with @YEAR_PLACEHOLDER@, consistent with the existing hook mechanism
- Update CONTRIBUTING.md to document the correct @YEAR_PLACEHOLDER@
  approach and remove guidance about the broken {% now %} extension

Fix LICENSE rendering (major template bug):
- Remove 'LICENSE' from _copy_without_render in cookiecutter.json so
  Jinja2 renders the {% if open_source_license %} conditionals correctly;
  previously every generated repo received raw Jinja syntax in LICENSE

Fix post-gen hook to honour feature toggles (closes flakiness reports):
- Remove docs/ and mkdocs.yml when docs != 'mkdocs'
- Remove Python module scaffold, example test, and model card when
  include_code_scaffold != 'Yes'
- Remove LICENSE when open_source_license == 'No license file'

Fixes #51 (make create_environment fails on macOS/Linux with virtualenv):
- Replace mkvirtualenv.bat fallback with portable python -m venv .venv

Fixes #49 (pre-commit autoupdate):
- Add 'make hooks-update' target that runs pre-commit autoupdate

Fix pre-commit config inconsistency:
- Template .pre-commit-config.yaml on linting_and_formatting choice:
  ruff or flake8+black+isort hooks now match the Makefile lint targets

Add regression test suite (tests/test_no_leftover_markers.py):
- Bakes all 11 configs.yaml combinations and asserts no leftover {%,
  {{, @YEAR_PLACEHOLDER@, or _-prefixed files remain
- Asserts docs/, module scaffold, and LICENSE are absent when their
  respective toggles disable them
- Asserts LICENSE contains correct licence text with no raw Jinja

https://claude.ai/code/session_01CCLNWrPiMN2zZfXyPTCnvh