### PR TITLE
Use shutil.which for cross-platform command detection

### DIFF
--- a/tests/test_setup_script.py
+++ b/tests/test_setup_script.py
@@ -113,3 +113,19 @@ class TestSetupScriptDocumentation:
 
         assert "def setup_precommit()" in content
         assert '"""Install pre-commit hooks' in content
+
+    def test_setup_script_command_check_is_cross_platform(self, cookies):
+        """Command availability check works on Windows.
+
+        The check must use ``shutil.which`` rather than the ``which``
+        command, which does not exist on Windows and aborted setup there
+        before the script's own Windows handling could run.
+        """
+        result = cookies.bake()
+
+        assert result.exit_code == 0
+        setup_script = result.project_path / "scripts" / "setup_repository.py"
+        content = setup_script.read_text()
+
+        assert "shutil.which" in content
+        assert '["which"' not in content

--- a/{{ cookiecutter.repo_name }}/scripts/setup_repository.py
+++ b/{{ cookiecutter.repo_name }}/scripts/setup_repository.py
@@ -13,6 +13,7 @@ Run this script after generating the project from the cookiecutter template.
 
 from __future__ import annotations
 
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -93,15 +94,10 @@ def check_command_available(cmd: str) -> bool:
     bool
         True if command is available, False otherwise
     """
-    try:
-        subprocess.run(
-            ["which", cmd],
-            capture_output=True,
-            check=True,
-        )
-        return True
-    except (subprocess.CalledProcessError, FileNotFoundError):
-        return False
+    # shutil.which resolves against PATH on every OS. The previous
+    # subprocess call to `which` failed on Windows, where that command
+    # does not exist, so setup aborted before its own Windows handling ran.
+    return shutil.which(cmd) is not None
 
 
 def setup_git_repository() -> None:


### PR DESCRIPTION
Closes #72.

`check_command_available` in the generated project's `scripts/setup_repository.py` detected commands by running `which` through `subprocess`. `which` does not exist on Windows, so the call raised and `make setup` reported the tool as missing (or aborted) before the script's own Windows-aware handling could run.

`shutil.which` resolves a command against `PATH` on every operating system and returns `None` when it is absent, so it is the standard-library, cross-platform way to do this. The function is now a single return, with the try/except removed.

Added a regression test in `tests/test_setup_script.py` that bakes the template and asserts the generated script uses `shutil.which` and no longer shells out to `which`.

Verified the fix and the rendered script's syntax locally. I ran the targeted tests rather than the full baked suite on Windows (the existing content tests read the baked file without an explicit encoding, which trips cp1252 on my machine, unrelated to this change), and confirmed the assertions hold when the file is read as UTF-8 as CI does.
